### PR TITLE
Fixes #52 Opening of social link in new tab 1.Added target attribute to Link component so that any link when clicked would open in new tab

### DIFF
--- a/src/components/SocialLink.jsx
+++ b/src/components/SocialLink.jsx
@@ -5,7 +5,7 @@ import PropTypes from "prop-types";
 const SocialLink = ({ icon, href, text }) => {
   return (
     <div>
-      <Link to={href} target={"_blank"}>
+      <Link to={href} target="_blank">
         <div
           className={`border border-black rounded-full 
           flex justify-center items-center hover:bg-black hover:text-white w-12 h-12`}

--- a/src/components/SocialLink.jsx
+++ b/src/components/SocialLink.jsx
@@ -5,7 +5,7 @@ import PropTypes from "prop-types";
 const SocialLink = ({ icon, href, text }) => {
   return (
     <div>
-      <Link to={href}>
+      <Link to={href} target={"_blank"}>
         <div
           className={`border border-black rounded-full 
           flex justify-center items-center hover:bg-black hover:text-white w-12 h-12`}


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Bug Fix


## Description

Fixed issue in opening the social link in new tab

## Related Tickets & Documents

- Related Issue #52
- Closes #52

## QA Instructions, Screenshots, Recordings

Open storybook for the social link and provide the href (valid one ) and click on the icon that should display the provided href in new tab
